### PR TITLE
chore(ci): add Biome schema version sync to Renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,7 +2,8 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "config:recommended",
-    ":semanticCommits"
+    ":semanticCommits",
+    "customManagers:biomeVersions"
   ],
   "packageRules": [
     {
@@ -14,8 +15,15 @@
     },
     {
       "description": "Group frontend dependency updates",
-      "matchManagers": ["bun", "npm"],
+      "matchManagers": ["bun", "npm", "custom.jsonata"],
       "matchFileNames": ["frontend/**"],
+      "groupName": "frontend",
+      "semanticCommitType": "chore",
+      "semanticCommitScope": "frontend"
+    },
+    {
+      "description": "Keep Biome package and biome.json schema version in sync",
+      "matchPackageNames": ["@biomejs/biome"],
       "groupName": "frontend",
       "semanticCommitType": "chore",
       "semanticCommitScope": "frontend"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
PR #11 was already merged with the grouped updates and semantic commits config. This follow-up adds Biome-specific integration so `frontend/biome.json` stays in sync with `@biomejs/biome`.

## Changes

- Add `customManagers:biomeVersions` preset ([Biome docs](https://biomejs.dev/recipes/renovate/)) to keep the `$schema` version in `biome.json` aligned with the installed package
- Include `custom.jsonata` in the frontend group so schema updates land in the same PR
- Add an explicit `@biomejs/biome` package rule to ensure `package.json` and `biome.json` update together

## Example

When `@biomejs/biome` is bumped from `2.2.6` to `2.5.4`, Renovate will update both:

- `frontend/package.json` → `"@biomejs/biome": "2.5.4"`
- `frontend/biome.json` → `"$schema": "https://biomejs.dev/schemas/2.5.4/schema.json"`

in the existing `chore(frontend):` grouped PR.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-439eda31-7259-46c0-88f9-263b070da7ec"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-439eda31-7259-46c0-88f9-263b070da7ec"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

