### PR TITLE
docs: add AGENTS.md with Cursor Cloud dev environment setup

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,41 @@
+# AGENTS.md
+
+## Cursor Cloud specific instructions
+
+Full-stack app (Neuland Member-ID): a Rust `backend/` API (signs/validates QR codes, builds
+wallet passes) and a Next.js `frontend/` scanner dashboard. See `README.md`, `backend/README.md`,
+and `frontend/README.md` for full docs. The update script already refreshes dependencies
+(`bun install` for the frontend, `cargo fetch` for the backend); you only need to start services.
+
+### Services & how to run them (dev)
+- Backend (Rust / Actix-web, port `8000`): `cd backend && cargo run`. First build is slow;
+  `rust-toolchain.toml` pins the stable toolchain (edition 2024, needs Rust >= 1.85 — auto-installed by rustup).
+- Frontend (Next.js dev, port `3000`): `cd frontend && bun run dev`. `bun` is on PATH via `~/.bashrc`
+  (installed at `~/.bun/bin`).
+- Reverse proxy (port `8540`): required for full E2E. `next dev` on `:3000` does NOT proxy `/api`,
+  and the frontend fetches `/api/public-key` (and other `/api/*`) relative to its own origin.
+  Run nginx proxying `/api/` → `127.0.0.1:8000/` and `/` → `127.0.0.1:3000`, then use
+  `http://localhost:8540` (mirrors the production `docker-compose.yml` + `nginx.conf`). Health:
+  `http://localhost:8540/api/health`, Swagger: `http://localhost:8540/api/swagger-ui/`.
+
+### Non-obvious gotchas
+- The backend reads env via `dotenv`, which loads `backend/.env` — NOT `.env.local`, despite the
+  template being named `backend/.env.local.example`. Copy it to `backend/.env`. Both `.env` and
+  `.env.local` are gitignored.
+- The backend needs `QR_PRIVATE_KEY_HEX` (a 32-byte hex scalar, e.g. `openssl rand -hex 32`) to
+  serve `/public-key` and `/qr`. Without it those endpoints error and the frontend scanner renders
+  "Scanner Unavailable" (it can't load the public key). Also set `JWKS_URL` and `EXPECTED_AUDIENCE`.
+- `/qr`, `/pkpass`, `/gpass` require a real member JWT verified against the external `JWKS_URL`
+  (Authentik SSO) with the `mitglieder` group claim — not available locally without real SSO
+  credentials. `/health` and `/public-key` work with just `QR_PRIVATE_KEY_HEX`.
+- The scanner is camera-only (no file upload / manual entry). To exercise it headlessly, feed a QR
+  image via Chrome's fake camera: `--use-fake-device-for-media-stream --use-fake-ui-for-media-stream
+  --use-file-for-fake-video-capture=<file.y4m>`. A valid QR is `zlib(CBOR{sub,name,t,iat,exp} ||
+  64-byte P-256 ECDSA sig)` then base45-encoded, signed with the same key as `QR_PRIVATE_KEY_HEX`.
+- Apple/Google Wallet features are optional and need external certs/credentials.
+
+### Lint / test / build
+- Backend: `cargo fmt --all -- --check`, `cargo clippy -- -D warnings`, `cargo test`
+  (run inside `backend/`; matches `.github/workflows/backend-ci.yml`).
+- Frontend: `bunx tsc --noEmit`, `bunx biome ci .` (run inside `frontend/`; matches
+  `.github/workflows/frontend-ci.yml`). `bun run build` produces a static export (`output: 'export'`).


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Sets up and verifies the development environment for the Neuland Member-ID monorepo (Rust `backend/` + Next.js `frontend/`), and documents durable, non-obvious startup guidance for future agents in a new `AGENTS.md`.

No application code was changed — the only tracked change is `AGENTS.md`.

## Environment setup

- **Rust** stable toolchain auto-installs via `rust-toolchain.toml` (edition 2024, `1.97.0`).
- **Bun** installed for the frontend (`~/.bun/bin`).
- **nginx** installed as the dev reverse proxy on port `8540` (mirrors production `docker-compose.yml` + `nginx.conf`): `/api/` → backend:8000, `/` → frontend:3000.
- Update script (dependency refresh only): `bun install --frozen-lockfile` (frontend) + `cargo fetch` (backend).

## Services verified

| Service | Lint / Test | Build / Run |
|---|---|---|
| backend (Rust, :8000) | `cargo fmt --all -- --check`, `cargo clippy -- -D warnings`, `cargo test` | `cargo build`, `cargo run` (→ `/health` 200, `/public-key` OK) |
| frontend (Next.js, :3000) | `bunx tsc --noEmit`, `bunx biome ci .` | `bun run dev` (Ready) |
| nginx proxy (:8540) | — | `/api/health`, `/api/public-key`, `/` all 200 |

## End-to-end "hello world"

Signed a QR with the backend's key, fed it into the scanner via Chrome's fake camera, and the app fetched the public key through nginx, verified the ECDSA signature, and validated member **"Ada Lovelace"** (Valid: 100%), then detected repeats as duplicates.

[member_id_qr_verification_demo.mp4](https://cursor.com/agents/bc-3572083c-1738-401a-8b57-614cdc200405/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fmember_id_qr_verification_demo.mp4)

[Valid scan with 100% valid stats](https://cursor.com/agents/bc-3572083c-1738-401a-8b57-614cdc200405/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fmember_id_valid_scan.webp)

## Notable gotcha documented in AGENTS.md

The backend loads `backend/.env` (via `dotenv`), NOT `.env.local`, despite the template being named `backend/.env.local.example`. Without `QR_PRIVATE_KEY_HEX` the `/public-key` endpoint errors and the frontend scanner shows "Scanner Unavailable".

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3572083c-1738-401a-8b57-614cdc200405"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3572083c-1738-401a-8b57-614cdc200405"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

