### PR TITLE
fix: include semester in Apple Wallet pass serial number

### DIFF
--- a/backend/src/passes.rs
+++ b/backend/src/passes.rs
@@ -203,7 +203,7 @@ pub async fn generate_pkpass(token: &str) -> Result<Vec<u8>, Box<dyn std::error:
         description: "Neuland Mitgliedsausweis".into(),
         pass_type_identifier,
         team_identifier,
-        serial_number: token_data.claims.sub,
+        serial_number: format!("{}.{}", token_data.claims.sub, semester_name),
     })
     .expiration_date(expiration_date)
     .fields(field_type)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Apple Wallet passes were issued with `serial_number` set to only the member `sub` claim. PassKit treats `passTypeIdentifier` + `serialNumber` as the unique pass identity.

When a member downloaded a pass for a new semester, iOS attempted to update the existing (expired) pass instead of adding a new one, which caused add failures after the first semester.

Google Wallet already scopes object IDs per semester (`{issuer_id}.{sub}.{semester_name}.10`).

## Fix

Include the current semester code in the Apple Wallet `serial_number`, e.g. `12345.SS25`, so each semester is a distinct pass.

## Testing

- `cargo fmt --all -- --check`
- `cargo clippy -- -D warnings`
- `cargo test`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a0266e-f25d-70b5-a368-9a7da4e519b6?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a0266e-f25d-70b5-a368-9a7da4e519b6&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

